### PR TITLE
Add(vector::insert): std::input_iterator_tag ver 追加

### DIFF
--- a/includes/containers/vector.hpp
+++ b/includes/containers/vector.hpp
@@ -74,11 +74,9 @@ public:
                                   InputIterator>::type* = NULL)
         : first_(NULL), last_(NULL), capacity_last_(NULL), alloc_(allocator)
     {
-        reserve(std::distance(first, last));
-        for (InputIterator i = first; i != last; ++i)
-        {
-            push_back(*i);
-        }
+        range_initialize(
+            first, last,
+            typename iterator_traits<InputIterator>::iterator_category());
     }
 
     vector(const vector& r)
@@ -396,6 +394,27 @@ private:
         for (reverse_iterator riter = rbegin(); riter != rend; ++riter, --last_)
         {
             destroy(&*riter);
+        }
+    }
+
+    template <class InputIterator>
+    void range_initialize(InputIterator first, InputIterator last,
+                          std::input_iterator_tag)
+    {
+        for (; first != last; ++first)
+        {
+            push_back(*first);
+        }
+    }
+
+    template <class ForwardIterator>
+    void range_initialize(ForwardIterator first, ForwardIterator last,
+                          std::forward_iterator_tag)
+    {
+        reserve(std::distance(first, last));
+        for (ForwardIterator i = first; i != last; ++i)
+        {
+            push_back(*i);
         }
     }
 

--- a/testfiles/test_vector.cpp
+++ b/testfiles/test_vector.cpp
@@ -650,6 +650,37 @@ void insert_test()
         v.insert(it, v2.begin(), v2.end());
         // vdebug(v);
     }
+
+    {
+        pout("When enough capacity, inserts input iterator elements from range "
+             "[first, last) "
+             "before pos.");
+
+        std::stringstream ss1;
+        ss1 << 1 << endl << 2 << endl << 3;
+        std::istream_iterator<int> is_it1(ss1);
+        std::istream_iterator<int> is_last1;
+
+        ft::vector<int> v(3, 100);
+        vdebug(v);
+
+        v.reserve(50);
+        // begin
+        ft::vector<int>::iterator it = v.begin();
+        v.insert(it + 1, is_it1, is_last1);
+        vdebug(v);
+
+        // end
+        std::stringstream ss2;
+        ss2 << 1 << endl << 2 << endl << 3;
+        std::istream_iterator<int> is_it2(ss2);
+        std::istream_iterator<int> is_last2;
+        it = v.end();
+        v.insert(it, is_it2, is_last2);
+        vdebug(v);
+    }
+
+
     {
         pout("When less capacity, inserts elements from range [first, last) "
              "before pos.");
@@ -675,6 +706,34 @@ void insert_test()
         // end
         it = v.end();
         v.insert(it, v4.begin(), v4.end());
+        vdebug(v);
+    }
+
+    {
+        pout("When less capacity, inserts input iterator elements from range "
+             "[first, last) "
+             "before pos.");
+
+        std::stringstream ss1;
+        ss1 << 1 << endl << 2 << endl << 3;
+        std::istream_iterator<int> is_it1(ss1);
+        std::istream_iterator<int> is_last1;
+
+        ft::vector<int> v(3, 100);
+        vdebug(v);
+
+        // begin
+        ft::vector<int>::iterator it = v.begin();
+        v.insert(it + 1, is_it1, is_last1);
+        vdebug(v);
+
+        // end
+        std::stringstream ss2;
+        ss2 << 1 << endl << 2 << endl << 3;
+        std::istream_iterator<int> is_it2(ss2);
+        std::istream_iterator<int> is_last2;
+        it = v.end();
+        v.insert(it, is_it2, is_last2);
         vdebug(v);
     }
 

--- a/testfiles/tester.hpp
+++ b/testfiles/tester.hpp
@@ -19,17 +19,18 @@ namespace ft = std;
 #include <time.h> // clock()
 
 #include <algorithm> //std::copy
-#include <cmath> //hypot set
+#include <cmath>     //hypot set
 #include <cstddef>   // size_t
 #include <ctime>
 #include <deque>
 #include <iomanip>
-#include <iostream>  // cout
-#include <list>      // std::list
-#include <numeric>
-#include <string>
-#include <typeinfo>  //typeid
+#include <iostream> // cout
+#include <list>     // std::list
 #include <memory>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <typeinfo> //typeid
 
 #define cout std::cout
 #define endl std::endl


### PR DESCRIPTION
`input_iterator_tag` のイテレータを挿入するときの処理を追加
```cpp
template <class InputIterator>
void range_initialize(InputIterator first, InputIterator last,
                      std::input_iterator_tag)
```

`range_initialize()` のオーバーロードで実現

About: #75
See Also: #69, #44