### PR TITLE
Add: map::operator[] の追加

### DIFF
--- a/gtest/map_test.cpp
+++ b/gtest/map_test.cpp
@@ -42,6 +42,22 @@ TEST(Map, Constructor)
     // map( const map& other );
 }
 
+TEST(Map, ElementAccess)
+{
+    // std::map<Key,T,Compare,Allocator>::at
+    ft::map<int, char> m;
+    for (int i = 0; i < 10; ++i)
+        m.insert(ft::make_pair(i, 'a' + static_cast<char>(i)));
+    for (int i = 0; i < 10; ++i)
+        EXPECT_EQ('a' + i, m[i]);
+    m[10] = 'x';
+    EXPECT_EQ('x', m[10]);
+    m[-42] = 'y';
+    EXPECT_EQ('y', m[-42]);
+    m[0] = 'z';
+    EXPECT_EQ('z', m[0]);
+}
+
 TEST(Map, ModifiersInsert)
 {
     // std::pair<iterator,bool> insert( const value_type& value );
@@ -85,7 +101,7 @@ TEST(Map, LookupLowerBound)
     EXPECT_TRUE(m.end() == it);
 
     // Const
-    ft::map<int, int>           cm = m;
+    ft::map<int, int>                 cm = m;
     ft::map<int, int>::const_iterator cit;
     cit = cm.lower_bound(0);
     EXPECT_EQ(0, (*cit).first);

--- a/includes/containers/map.hpp
+++ b/includes/containers/map.hpp
@@ -110,6 +110,15 @@ public:
 
     ~map() {}
 
+    // Element access
+    // Returns a reference to the value that is mapped to a key equivalent to
+    // key, performing an insertion if such key does not already exist.
+
+    mapped_type& operator[](const key_type& key)
+    {
+        return insert(ft::make_pair(key, mapped_type())).first->second;
+    }
+
     iterator               begin() { return tree_.begin(); }
     const_iterator         begin() const { return tree_.begin(); }
     iterator               end() { return tree_.end(); }


### PR DESCRIPTION
mapped_typeにアクセスするためのoperator[] を追加

About: #134
See Also: #54