### PR TITLE
Add: map::clear 関数の追加

### DIFF
--- a/gtest/map_test.cpp
+++ b/gtest/map_test.cpp
@@ -86,6 +86,15 @@ TEST(Map, ModifiersInsert)
     }
 }
 
+TEST(Map, ModifiersClear)
+{
+    ft::map<int, int> m;
+    for (int i = 0; i < 10; ++i)
+        m.insert(ft::make_pair(i, i));
+    m.clear();
+    m.clear();
+}
+
 TEST(Map, LookupLowerBound)
 {
     // Non const

--- a/includes/containers/map.hpp
+++ b/includes/containers/map.hpp
@@ -133,6 +133,8 @@ public:
     size_type max_size() { return tree_.max_size(); }
 
     // Modifiers
+    void clear() { tree_.clear(); }
+
     ft::pair<iterator, bool> insert(const value_type& v)
     {
         return tree_.insert(v);

--- a/includes/utils/tree.hpp
+++ b/includes/utils/tree.hpp
@@ -365,7 +365,7 @@ public:
         destroy(root());
         size_      = 0;
         begin_     = end_;
-        end_->left = NULL;
+        end_->left = nil_;
     }
 
     // private:


### PR DESCRIPTION
要素を全て削除する(内部でtree_.clear)を呼ぶ

About: #54